### PR TITLE
Fix undefined user errors

### DIFF
--- a/locking/static/locking/js/locking.admin.js
+++ b/locking/static/locking/js/locking.admin.js
@@ -26,6 +26,12 @@
             $('.locking-status.locked').removeClass('locked').removeAttr('title');
             for (var i = 0; i < data.length; i++) {
                 user = data[i]['locked_by'];
+                // Occasionally the user will be logged out but will still have a browser tab
+                // open with a page calling the locking api.
+                if (!user) {
+                  return;
+                }
+
                 if (user['username'] === self.currentUser) {
                     lockedMessage = self.lockedByMeText;
                     lockedClass = "editing";


### PR DESCRIPTION
On occasion, the user will not be defined yet in the context of the browser
environment when the server locking ping occurs and is resolved. In this
instance, we suspend the update until the next successful ping.

refs: DEV-23982