### PR TITLE
Fix onbeforeunload lock delete bug, a py3 compat bug, a race condition bug, and make travis tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,30 @@ install:
 before_script:
   - flake8 --max-line-length=100 --exclude=migrations locking
 
+cache:
+  pip: true
+  directories:
+    - bin
+
+addons:
+  chrome: stable
+
+env:
+  global:
+    - PATH=$HOME/bin:$PATH
+    - CHROME_HEADLESS=1
+
+before_script:
+  - mkdir -p ~/bin
+  - |
+    if [ ! -e ~/bin/chromedriver ]; then
+      export CHROMEDRIVER_VERSION=$(curl -q http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+      wget -N http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip -P ~/
+      unzip ~/chromedriver_linux64.zip -d ~/bin
+      rm ~/chromedriver_linux64.zip
+      chmod +x ~/bin/chromedriver
+    fi
+
 matrix:
   include:
     - { python: 2.7, env: TOXENV=py27-django111 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 
-python:
-  - 2.7
-
 sudo: false
 
 install:
@@ -13,23 +10,23 @@ install:
 before_script:
   - flake8 --max-line-length=100 --exclude=migrations locking
 
-env:
-  - TOXENV=py27-django111
-  - TOXENV=py34-django111
-  - TOXENV=py34-django20
-  - TOXENV=py34-django21
-  - TOXENV=py35-django111
-  - TOXENV=py35-django20
-  - TOXENV=py35-django21
-  - TOXENV=py36-django111
-  - TOXENV=py36-django20
-  - TOXENV=py36-django21
-  - TOXENV=py37-django20
-  - TOXENV=py37-django21
-  - TOXENV=py27-django111-grappelli
-  - TOXENV=py34-django111-grappelli
-  - TOXENV=py35-django111-grappelli
-  - TOXENV=py36-django111-grappelli
+matrix:
+  include:
+    - { python: 2.7, env: TOXENV=py27-django111 }
+    - { python: 3.4, env: TOXENV=py34-django111 }
+    - { python: 3.4, env: TOXENV=py34-django20 }
+    - { python: 3.5, env: TOXENV=py35-django111 }
+    - { python: 3.5, env: TOXENV=py35-django20 }
+    - { python: 3.5, env: TOXENV=py35-django21 }
+    - { python: 3.6, env: TOXENV=py36-django111 }
+    - { python: 3.6, env: TOXENV=py36-django20 }
+    - { python: 3.6, env: TOXENV=py36-django21 }
+    - { python: 3.7, env: TOXENV=py37-django20 }
+    - { python: 3.7, env: TOXENV=py37-django21 }
+    - { python: 2.7, env: TOXENV=py27-django111-grappelli }
+    - { python: 3.4, env: TOXENV=py34-django111-grappelli }
+    - { python: 3.5, env: TOXENV=py35-django111-grappelli }
+    - { python: 3.6, env: TOXENV=py36-django111-grappelli }
 
 script:
   - travis_retry tox

--- a/locking/admin.py
+++ b/locking/admin.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals, division
 import json
 import types
 
+import six
+
 from django import forms
 from django.conf import settings
 from django.conf.urls import url
@@ -176,12 +178,8 @@ class LockingAdminMixin(object):
         """If editing an existing object, add form locking media to the media context"""
         if not add and getattr(obj, 'pk', False):
             locking_media = forms.Media(js=(self.locking_admin_form_js_url(obj.pk), ))
-            try:
-                str_type = basestring
-            except NameError:  # basestring does not exist in Python3
-                str_type = str
-            if isinstance(context['media'], str_type):
-                locking_media = unicode(locking_media)
+            if isinstance(context['media'], six.string_types):
+                locking_media = six.text_type(locking_media)
             context['media'] += locking_media
         return super(LockingAdminMixin, self).render_change_form(
             request, context, add=add, obj=obj, **kwargs)

--- a/locking/api.py
+++ b/locking/api.py
@@ -59,6 +59,11 @@ class LockAPIView(View):
 
     def post(self, request, app, model, object_id):
         """Create or maintain a lock on an object if possible"""
+        # Allow for deletion by GET parameter for Navigator.sendBeacon POST
+        # requests called by the onbeforeunload event handler
+        if request.GET.get('method') == 'delete':
+            return self.delete(request, app, model, object_id)
+
         try:
             lock = Lock.objects.lock_for_user(content_type=self.lock_ct_type,
                                               object_id=object_id,

--- a/locking/static/locking/js/locking.js
+++ b/locking/static/locking/js/locking.js
@@ -151,10 +151,20 @@
             // Unlock the form when leaving the page
             $(window).on('beforeunload submit', function() {
                 if (self.hasLock && self.removeLockOnUnload) {
-                    // We have to assure that our unlock request gets
-                    // through before the user leaves the page, so it
-                    // shouldn't run asynchronously.
-                    self.api.unlock({'async': false});
+                    // We have to assure that our unlock request gets through
+                    // before the user leaves the page, so it shouldn't run
+                    // asynchronously.
+                    //
+                    // However, newer browser versions have deprecated
+                    // synchronous AJAX calls, and instead provide a "Beacon"
+                    // API for sending requests before a page unloads. If
+                    // window.navigator.sendBeacon is available we use it
+                    // instead of a synchronous AJAX call
+                    if (typeof navigator.sendBeacon === 'function') {
+                        navigator.sendBeacon(self.api.apiURL + '?method=delete');
+                    } else {
+                        self.api.unlock({'async': false});
+                    }
                     self.hasLock = false;
                 }
             });

--- a/locking/static/locking/js/locking.js
+++ b/locking/static/locking/js/locking.js
@@ -141,33 +141,6 @@
             this.confirmTakeLockText = opts.messages.confirmTakeLockText;
             this.networkWarningText = opts.messages.networkWarningText;
             this.lockWasTakenByUserText = opts.messages.lockWasTakenByUserText;
-
-            // Attempt to get a lock
-            this.getLock();
-
-            // Attempt to get / maintain a lock ever ping number of seconds
-            setInterval(function() { self.getLock(); }, self.ping * 1000);
-
-            // Unlock the form when leaving the page
-            $(window).on('beforeunload submit', function() {
-                if (self.hasLock && self.removeLockOnUnload) {
-                    // We have to assure that our unlock request gets through
-                    // before the user leaves the page, so it shouldn't run
-                    // asynchronously.
-                    //
-                    // However, newer browser versions have deprecated
-                    // synchronous AJAX calls, and instead provide a "Beacon"
-                    // API for sending requests before a page unloads. If
-                    // window.navigator.sendBeacon is available we use it
-                    // instead of a synchronous AJAX call
-                    if (typeof navigator.sendBeacon === 'function') {
-                        navigator.sendBeacon(self.api.apiURL + '?method=delete');
-                    } else {
-                        self.api.unlock({'async': false});
-                    }
-                    self.hasLock = false;
-                }
-            });
         },
 
         /**

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author='Josh West',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[],
+    install_requires=['six'],
     zip_safe=False,
     keywords=['Django', 'admin', 'locking'],
     classifiers=[

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -171,11 +171,15 @@ class TestLiveAdmin(StaticLiveServerTestCase):
         self._login('admin:locking_blogarticle_change', self.blog_article.pk)
         self._wait_for_ajax()
         self.assert_no_js_errors()
+
+        self._wait_until(lambda b: len(Lock.objects.for_object(self.blog_article)) == 1,
+            "Timeout waiting for lock creation")
+
         self._load('admin:locking_blogarticle_changelist')
 
         # Check that lock was deleted
-        locks = Lock.objects.for_object(self.blog_article)
-        self.assertEqual(len(locks), 0)
+        self._wait_until(lambda b: len(Lock.objects.for_object(self.blog_article)) == 0,
+            "Timeout waiting for lock removal")
 
     def test_changeform_locked_by_other_user(self):
         other_user, _ = user_factory(model=BlogArticle)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -227,7 +227,7 @@ class TestLiveAdmin(StaticLiveServerTestCase):
         self.browser.find_element_by_id('locking-take-lock').click()
         
         WebDriverWait(self.browser, 10).until(EC.alert_is_present())
-        self.browser.switch_to_alert().accept()
+        self.browser.switch_to.alert.accept()
         self._wait_for_ajax()
 
         lock = Lock.objects.for_object(self.blog_article)[0]
@@ -245,7 +245,7 @@ class TestLiveAdmin(StaticLiveServerTestCase):
         self.browser.find_element_by_id('locking-take-lock').click()
 
         WebDriverWait(self.browser, 10).until(EC.alert_is_present())
-        self.browser.switch_to_alert().accept()
+        self.browser.switch_to.alert.accept()
 
         # ensure the page has reloaded
         WebDriverWait(self.browser, 10).until(staleness_of(body_el))
@@ -283,7 +283,7 @@ class TestLiveAdmin(StaticLiveServerTestCase):
         Lock.objects.force_lock_object_for_user(user=other_user, obj=self.blog_article)
 
         WebDriverWait(self.browser, 10).until(EC.alert_is_present())
-        self.browser.switch_to_alert().accept()
+        self.browser.switch_to.alert.accept()
 
         self.assertTrue(self.browser.find_element_by_id('id_title').get_attribute('disabled'))
         self.assertTrue(self.browser.find_element_by_id('id_content').get_attribute('disabled'))
@@ -310,7 +310,7 @@ class TestLiveAdmin(StaticLiveServerTestCase):
         lock_icon.click()
 
         WebDriverWait(self.browser, 10).until(EC.alert_is_present())
-        self.browser.switch_to_alert().accept()
+        self.browser.switch_to.alert.accept()
         self._wait_for_ajax()
 
         lock = Lock.objects.for_object(self.blog_article)[0]

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -181,6 +181,19 @@ class TestLiveAdmin(StaticLiveServerTestCase):
         self._wait_until(lambda b: len(Lock.objects.for_object(self.blog_article)) == 0,
             "Timeout waiting for lock removal")
 
+    def test_changeform_unlocks_for_user_after_close(self):
+        self._login('admin:locking_blogarticle_change', self.blog_article.pk)
+        self._wait_for_ajax()
+        self.assert_no_js_errors()
+
+        self._wait_until(lambda b: len(Lock.objects.for_object(self.blog_article)) == 1,
+            "Timeout waiting for lock creation")
+
+        self.browser.get('about:blank')
+
+        self._wait_until(lambda b: len(Lock.objects.for_object(self.blog_article)) == 0,
+            "Timeout waiting for lock removal")
+
     def test_changeform_locked_by_other_user(self):
         other_user, _ = user_factory(model=BlogArticle)
         Lock.objects.force_lock_object_for_user(self.blog_article, other_user)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -131,8 +131,13 @@ class TestLiveAdmin(StaticLiveServerTestCase):
 
         # Instantiate and login Selenium browser. You must have chromedriver somewhere
         # on your path
-        self.browser = webdriver.Chrome()
-        self.browser.set_window_size(1120, 550)
+        options = webdriver.ChromeOptions()
+        if os.environ.get('CHROME_HEADLESS'):
+            options.add_argument('headless')
+            options.add_argument('disable-gui')
+            options.add_argument('no-sandbox')
+        options.add_argument('window-size=1120x550')
+        self.browser = webdriver.Chrome(options=options)
         self.browser.set_page_load_timeout(10)
         self.user, self.password = user_factory(BlogArticle)
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ envlist =
 commands =
     coverage run manage.py test --settings=tests.settings {posargs}
 
+passenv =
+    CHROME_HEADLESS
+
 deps =
     coverage
     selenium


### PR DESCRIPTION
Fixes FUN-2077

Three actual bug fixes, and three unit test fixes bundled in here. Happy to split them up. I had initially set out to fix one bug (listed below as Bug fix 1) and had to make several other changes to get the travis tests to pass. The test failures caught a python 3 bug and an actual race condition bug, but the tests also needed more robust `WebDriverWait` checks to make sure it wasn't asserting things before an action completed or a page loaded.

In short, all of the things needed fixing before my regression test for Bug 1 would pass.

#### Bug fix 1 (5f92c63)

Modern browsers have deprecated synchronous AJAX calls, so `$.ajax({async:  true})` no longer does anything in recent version of Chrome, Firefox, Safari, or Edge. Instead, the recommendation is to use the [Navigator.sendBeacon API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) for http requests that need to be executed after a user leaves a page.

If the browser has support for the `Navigator.sendBeacon` method, it is used instead of the async AJAX call for submit and beforeunload events.

Since `Navigator.sendBeacon` only sends POST requests, and the locking API uses HTTP methods in a REST-like fashion, I've had to enable the ability to use a GET parameter to call the DELETE handler (specifically, with `?method=delete`).


#### Bug fix 2 (9c34ddf)

There was a call to `unicode()`, which was failing the flake8 check, and was incompatible with python 3.

#### Bug fix 3 (59f4351)

The change_view locking javascript was making an AJAX call to get a lock, even if the user had just requested ownership of the lock. It was then making a subsequent request to forcibly take the lock. If the first AJAX call succeeded before the second, it would popup an alert telling the user the article was locked by somebody else.

This change makes it so that it only ever calls `LockingForm.prototype.getLock()` or `LockingForm.prototype.takeLock()` when initializing, but never both.

#### Test fix 1 (b69dc52)

The `.travis.yml` file was setting the python version to 2.7, but was then using tox with other python versions. I've switched to using a test matrix to ensure that the necessary python version is installed for a given TOXENV.

#### Test fix 2 (f787bcd)

The selenium tests were failing on travis, because 1) chromedriver wasn't installed, 2) chrome wasn't installed, and 3) it wasn't using headless mode. These issues are now all resolved. I think that at an earlier time travis might have always bundled Chrome with the build images, which is why these tests might have worked in the past.

#### Test fix 3 (159712a)

There were various places where the selenium might execute a check before a page was fully finished loading, or before an asynchronous API call completed. I've gone through and added more robust selenium wait timeouts to help ensure we get fewer sporadic test failures.