### PR TITLE
Update the tox and travis testing matrix to include Django 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ghostdriver.log
 /coverage/
 /build/
 /dist/
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,20 +37,12 @@ before_script:
 matrix:
   include:
     - { python: 2.7, env: TOXENV=py27-django111 }
-    - { python: 3.4, env: TOXENV=py34-django111 }
-    - { python: 3.4, env: TOXENV=py34-django20 }
-    - { python: 3.5, env: TOXENV=py35-django111 }
-    - { python: 3.5, env: TOXENV=py35-django20 }
-    - { python: 3.5, env: TOXENV=py35-django21 }
-    - { python: 3.6, env: TOXENV=py36-django111 }
-    - { python: 3.6, env: TOXENV=py36-django20 }
-    - { python: 3.6, env: TOXENV=py36-django21 }
     - { python: 3.7, env: TOXENV=py37-django20 }
-    - { python: 3.7, env: TOXENV=py37-django21 }
+    - { python: 3.7, env: TOXENV=py37-django22 }
     - { python: 2.7, env: TOXENV=py27-django111-grappelli }
-    - { python: 3.4, env: TOXENV=py34-django111-grappelli }
-    - { python: 3.5, env: TOXENV=py35-django111-grappelli }
-    - { python: 3.6, env: TOXENV=py36-django111-grappelli }
+    - { python: 3.7, env: TOXENV=py37-django111-grappelli }
+    - { python: 3.7, env: TOXENV=py37-django20-grappelli }
+    - { python: 3.7, env: TOXENV=py37-django22-grappelli }
 
 script:
   - travis_retry tox

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Prevents users from overwriting each others changes in Django.
 
 Django Admin Locking is tested in the following environments
 
-* Python (2.7, 3.4, 3.5, 3.6, 3.7)
-* Django (1.11, 2.0, 2.1)
+* Python (2.7, 3.7)
+* Django (1.11, 2.0, 2.2)
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-admin-locking',
-    version='1.7.0',
+    version='1.8.0',
     url='https://github.com/theatlantic/django-admin-locking',
-    download_url='https://github.com/theatlantic/django-admin-locking/tarball/v1.6',
+    download_url='https://github.com/theatlantic/django-admin-locking/tarball/v1.8.0',
     license='BSD',
     description='Prevents users from overwriting each others changes in Django.',
     author='Josh West',
@@ -19,13 +19,10 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -60,6 +60,7 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': (
                 'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
             ),
         }
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-django111
-    {py34,py35,py36,py37}-django20
-    {py35,py36,py37}-django21
-    {py27,py34,py35,py36}-django111-grappelli
+    {py27,py37}-django111
+    py37-django{20,22}
+    {py27}-django111-grappelli
+    py37-django{20,22}-grappelli
 
 [testenv]
 commands =
@@ -18,6 +18,8 @@ deps =
 
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<3.0
 
     django111-grappelli: django-grappelli>=2.10,<2.11
+    django20-grappelli: django-grappelli>=2.10,<2.11
+    django22-grappelli: django-grappelli>=2.10,<2.11


### PR DESCRIPTION
Also includes tests for Grappelli on Django 2.0 & 2.2, and removes all other unsupported versions.

Being that this app isn't in PyPI (in fact, there is a another app available there with the same name) *and* someone else has forked this repo and upload _that_ version to PyPI, I felt that at this point we should only continue supporting the exact versions that we are interested in at this point in time.

I have also reached out the Josh to see about transferring his original repo to The Atlantic, so we're working through that. This may entail renaming and/or retiring this repo.