### PR TITLE
Explicitly include admin js dependencies for django 2.2 compat

### DIFF
--- a/locking/admin.py
+++ b/locking/admin.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import, unicode_literals, division
 import json
 import types
 
-import six
-
 from django import forms
 from django.conf import settings
 from django.conf.urls import url
@@ -49,7 +47,8 @@ class LockingAdminMixin(object):
     @property
     def media(self):
         media = super(LockingAdminMixin, self).media + forms.Media(
-            js=('locking/js/locking.js',
+            js=('admin/js/jquery.init.js',
+                'locking/js/locking.js',
                 'locking/js/locking.admin.js',
                 self.locking_admin_changelist_js_url()),
             css={'all': ('locking/css/changelist.css', )}
@@ -177,9 +176,12 @@ class LockingAdminMixin(object):
     def render_change_form(self, request, context, add=False, obj=None, **kwargs):
         """If editing an existing object, add form locking media to the media context"""
         if not add and getattr(obj, 'pk', False):
-            locking_media = forms.Media(js=(self.locking_admin_form_js_url(obj.pk), ))
-            if isinstance(context['media'], six.string_types):
-                locking_media = six.text_type(locking_media)
+            locking_media = forms.Media(js=(
+                'admin/js/jquery.init.js',
+                'locking/js/locking.js',
+                'locking/js/locking.admin.js',
+                self.locking_admin_form_js_url(obj.pk),
+            ))
             context['media'] += locking_media
         return super(LockingAdminMixin, self).render_change_form(
             request, context, add=add, obj=obj, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     license='BSD',
     description='Prevents users from overwriting each others changes in Django.',
     author='Josh West',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=['six'],
     zip_safe=False,


### PR DESCRIPTION
See the [Merging of form `Media` assets](https://docs.djangoproject.com/en/3.1/releases/2.2/#merging-of-form-media-assets)  section in the Django 2.2 release notes:

> Form `Media` assets are now merged using a topological sort algorithm, as the old pairwise merging algorithm is insufficient for some cases. CSS and JavaScript files which don’t include their dependencies may now be sorted incorrectly (where the old algorithm produced results correctly by coincidence).
>
> Audit all `Media` classes for any missing dependencies. For example, widgets depending on `django.jQuery` must specify `js=['admin/js/jquery.init.js', ...]` when declaring form media assets.

Also includes a commit to exclude the tests package in setup.py