### PR TITLE
CSRF 3.2 Fix

### DIFF
--- a/locking/static/locking/js/locking.js
+++ b/locking/static/locking/js/locking.js
@@ -42,6 +42,7 @@
                 headers: {
                     "X-CSRFToken": csrftoken,
                 },
+                mode: 'same-origin' // Do not send CSRF token to another domain.
             };
             var self = this;
             this._onAjaxStart();

--- a/locking/static/locking/js/locking.js
+++ b/locking/static/locking/js/locking.js
@@ -34,10 +34,14 @@
     };
     $.extend(locking.API.prototype, {
         ajax: function(opts) {
+            const csrftoken = document.querySelector("[name=csrfmiddlewaretoken]").value;
             var defaults = {
                 url: this.apiURL,
                 async: true,
-                cache: false
+                cache: false,
+                headers: {
+                    "X-CSRFToken": csrftoken,
+                },
             };
             var self = this;
             this._onAjaxStart();


### PR DESCRIPTION
I'm working on upgrading Hattie to Django 3.2, and there were errors with this package. The `/locking/api/lock/<app>/<model>/<pk>/` endpoint is expecting a CSRF Token and not getting it.

We're currently sending a "HTTP_X_CSRFTOKEN" header. However, [in these docs for 3.2 for CSRF_HEADER_NAME](https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-header-name) it says

> ... if your client sends a 'X-XSRF-TOKEN' header, the setting should be 'HTTP_X_XSRF_TOKEN'.

The default CSRF_HEADER_NAME is "HTTP_X_CSRFTOKEN", and we're using the default, so we need to be sending 'X-CSRFTOKEN'. I truly have no idea how to retrieve the value of the CSRF_HEADER_NAME setting in this javacript file if we set it to something other than the default.

The code is [straight out of the 3.2 docs here](https://docs.djangoproject.com/en/3.2/ref/csrf/#acquiring-the-token-if-csrf-use-sessions-or-csrf-cookie-httponly-is-true).

Strangely enough, [the 2.2 settings docs](https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-header-name) say the same thing about this. However, sending only "HTTP_X_CSRFTOKEN"  instead of 'X-CSRFTOKEN' is working in Hattie prod currently using 2.2, despite the [2.2 csrf docs](https://docs.djangoproject.com/en/2.2/ref/csrf/#acquiring-the-token-if-csrf-use-sessions-or-csrf-cookie-httponly-is-true) giving similar directions to send a "X-CSRFToken" request header.

I obviously could be missing something here!