### PR TITLE
Update collections import syntax

### DIFF
--- a/locking/api.py
+++ b/locking/api.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, unicode_literals, division
 
-from collections.abc import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required

--- a/locking/api.py
+++ b/locking/api.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals, division
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required


### PR DESCRIPTION
The existing module import syntax has been deprecated since Python 3.3, and is no longer works with Python 3.10.

Use a try/except block to stay compatible with Python2.7, which requires the existing module import syntax.

Docs: 
- https://docs.python.org/3/library/collections.abc.html
- https://docs.python.org/3/whatsnew/3.10.html#removed
- https://github.com/python/cpython/commit/c47c78b878ff617164b2b94ff711a6103e781753
- https://stackoverflow.com/a/53978543/1960231
